### PR TITLE
Testsuite, aarch64: Add correct requirements for bf16 and i8mm

### DIFF
--- a/gcc/testsuite/gcc.target/aarch64/advsimd-intrinsics/bf16_dup.c
+++ b/gcc/testsuite/gcc.target/aarch64/advsimd-intrinsics/bf16_dup.c
@@ -1,4 +1,5 @@
 /* { dg-do assemble { target { aarch64*-*-* } } } */
+/* { dg-require-effective-target aarch64_asm_bf16_ok }  */
 /* { dg-require-effective-target arm_v8_2a_bf16_neon_ok } */
 /* { dg-options "-O2" } */
 /* { dg-add-options arm_v8_2a_bf16_neon }  */

--- a/gcc/testsuite/gcc.target/aarch64/advsimd-intrinsics/bf16_get.c
+++ b/gcc/testsuite/gcc.target/aarch64/advsimd-intrinsics/bf16_get.c
@@ -1,4 +1,5 @@
 /* { dg-do assemble { target { aarch64*-*-* } } } */
+/* { dg-require-effective-target aarch64_asm_bf16_ok }  */
 /* { dg-require-effective-target arm_v8_2a_bf16_neon_ok } */
 /* { dg-add-options arm_v8_2a_bf16_neon } */
 /* { dg-additional-options "-save-temps" } */

--- a/gcc/testsuite/gcc.target/aarch64/advsimd-intrinsics/bf16_reinterpret.c
+++ b/gcc/testsuite/gcc.target/aarch64/advsimd-intrinsics/bf16_reinterpret.c
@@ -1,4 +1,5 @@
 /* { dg-do assemble { target { aarch64*-*-* } } } */
+/* { dg-require-effective-target aarch64_asm_bf16_ok }  */
 /* { dg-require-effective-target arm_v8_2a_bf16_neon_ok } */
 /* { dg-add-options arm_v8_2a_bf16_neon }  */
 /* { dg-additional-options "-save-temps" } */

--- a/gcc/testsuite/gcc.target/aarch64/advsimd-intrinsics/bfcvt-compile.c
+++ b/gcc/testsuite/gcc.target/aarch64/advsimd-intrinsics/bfcvt-compile.c
@@ -1,4 +1,5 @@
 /* { dg-do assemble { target { aarch64*-*-* } } } */
+/* { dg-require-effective-target aarch64_asm_bf16_ok }  */
 /* { dg-require-effective-target arm_v8_2a_bf16_neon_ok } */
 /* { dg-add-options arm_v8_2a_bf16_neon } */
 /* { dg-additional-options "-save-temps" } */

--- a/gcc/testsuite/gcc.target/aarch64/advsimd-intrinsics/bfcvtnq2-untied.c
+++ b/gcc/testsuite/gcc.target/aarch64/advsimd-intrinsics/bfcvtnq2-untied.c
@@ -1,4 +1,5 @@
 /* { dg-do assemble { target { aarch64*-*-* } } } */
+/* { dg-require-effective-target aarch64_asm_bf16_ok }  */
 /* { dg-require-effective-target arm_v8_2a_bf16_neon_ok } */
 /* { dg-add-options arm_v8_2a_bf16_neon } */
 /* { dg-additional-options "-save-temps" } */

--- a/gcc/testsuite/gcc.target/aarch64/advsimd-intrinsics/bfdot-1.c
+++ b/gcc/testsuite/gcc.target/aarch64/advsimd-intrinsics/bfdot-1.c
@@ -1,4 +1,5 @@
 /* { dg-do assemble { target { aarch64*-*-* } } } */
+/* { dg-require-effective-target aarch64_asm_bf16_ok }  */
 /* { dg-require-effective-target arm_v8_2a_bf16_neon_ok } */
 /* { dg-add-options arm_v8_2a_bf16_neon }  */
 /* { dg-additional-options "-save-temps" } */

--- a/gcc/testsuite/gcc.target/aarch64/advsimd-intrinsics/bfmlalbt-compile.c
+++ b/gcc/testsuite/gcc.target/aarch64/advsimd-intrinsics/bfmlalbt-compile.c
@@ -1,4 +1,5 @@
 /* { dg-do assemble { target { aarch64*-*-* } } } */
+/* { dg-require-effective-target aarch64_asm_bf16_ok }  */
 /* { dg-require-effective-target arm_v8_2a_bf16_neon_ok } */
 /* { dg-add-options arm_v8_2a_bf16_neon } */
 /* { dg-additional-options "-save-temps" } */

--- a/gcc/testsuite/gcc.target/aarch64/advsimd-intrinsics/bfmmla-compile.c
+++ b/gcc/testsuite/gcc.target/aarch64/advsimd-intrinsics/bfmmla-compile.c
@@ -1,4 +1,5 @@
 /* { dg-do assemble { target { aarch64*-*-* } } } */
+/* { dg-require-effective-target aarch64_asm_bf16_ok }  */
 /* { dg-require-effective-target arm_v8_2a_bf16_neon_ok } */
 /* { dg-add-options arm_v8_2a_bf16_neon } */
 /* { dg-additional-options "-save-temps" } */

--- a/gcc/testsuite/gcc.target/aarch64/advsimd-intrinsics/vdot-3-1.c
+++ b/gcc/testsuite/gcc.target/aarch64/advsimd-intrinsics/vdot-3-1.c
@@ -1,4 +1,5 @@
 /* { dg-do assemble { target { aarch64*-*-* } } } */
+/* { dg-require-effective-target arm_v8_2a_i8mm_neon_hw } */
 /* { dg-require-effective-target arm_v8_2a_i8mm_ok } */
 /* { dg-add-options arm_v8_2a_i8mm }  */
 /* { dg-additional-options "-save-temps" } */


### PR DESCRIPTION
gcc/testsuite/ChangeLog:

	* gcc.target/aarch64/advsimd-intrinsics/bf16_dup.c: Require aarch64_asm_bf16_ok.
	* gcc.target/aarch64/advsimd-intrinsics/bf16_get.c: Require aarch64_asm_bf16_ok.
	* gcc.target/aarch64/advsimd-intrinsics/bf16_reinterpret.c: Require aarch64_asm_bf16_ok.
	* gcc.target/aarch64/advsimd-intrinsics/bfcvt-compile.c: Require aarch64_asm_bf16_ok.
	* gcc.target/aarch64/advsimd-intrinsics/bfcvtnq2-untied.c: Require aarch64_asm_bf16_ok.
	* gcc.target/aarch64/advsimd-intrinsics/bfdot-1.c: Require aarch64_asm_bf16_ok.
	* gcc.target/aarch64/advsimd-intrinsics/bfmlalbt-compile.c: Require aarch64_asm_bf16_ok.
	* gcc.target/aarch64/advsimd-intrinsics/bfmmla-compile.c: Require aarch64_asm_bf16_ok.
	* gcc.target/aarch64/advsimd-intrinsics/vdot-3-1.c: Require arm_v8_2a_i8mm_neon_hw.