### PR TITLE
Testsuite: Adjust a Fortran error check

### DIFF
--- a/gcc/testsuite/gfortran.dg/pr95690.f90
+++ b/gcc/testsuite/gfortran.dg/pr95690.f90
@@ -2,8 +2,8 @@
 module m
 contains
    subroutine s
-      print *, (erfc) ! { dg-error "not a floating constant" "" { target i?86-*-* x86_64-*-* sparc*-*-* cris-*-* } }
-   end ! { dg-error "not a floating constant" "" { target { ! "i?86-*-* x86_64-*-* sparc*-*-* cris-*-*" } } }
+      print *, (erfc) ! { dg-error "not a floating constant" "" { target i?86-*-* x86_64-*-* sparc*-*-* cris-*-* aarch64-apple-darwin* } }
+   end ! { dg-error "not a floating constant" "" { target { ! "i?86-*-* x86_64-*-* sparc*-*-* cris-*-* aarch64-apple-darwin*" } } }
    function erfc()
    end
 end


### PR DESCRIPTION
gcc/testsuite/ChangeLog

	* gfortran.dg/pr95690.f90: Adjust error check on
	aarch64-apple-darwin.