### PR TITLE
Testsuite: skip non-Darwin ABI tests

### DIFF
--- a/gcc/testsuite/g++.target/aarch64/pr109661-1.C
+++ b/gcc/testsuite/g++.target/aarch64/pr109661-1.C
@@ -1,4 +1,5 @@
 /* { dg-options "-O2 -Wpsabi" } */
+/* { dg-skip-if "Darwin ABI is different, test separately" { *-*-darwin* } } */
 /* { dg-final { check-function-bodies "**" "" "" } } */
 
 #include <stdarg.h>

--- a/gcc/testsuite/g++.target/aarch64/pr109661-2.C
+++ b/gcc/testsuite/g++.target/aarch64/pr109661-2.C
@@ -1,4 +1,5 @@
 /* { dg-options "-O2 -Wpsabi" } */
+/* { dg-skip-if "Darwin ABI is different, test separately" { *-*-darwin* } } */
 /* { dg-final { check-function-bodies "**" "" "" } } */
 
 #include <stdarg.h>

--- a/gcc/testsuite/g++.target/aarch64/pr109661-3.C
+++ b/gcc/testsuite/g++.target/aarch64/pr109661-3.C
@@ -1,4 +1,5 @@
 /* { dg-options "-O2 -Wpsabi" } */
+/* { dg-skip-if "Darwin ABI is different, test separately" { *-*-darwin* } } */
 /* { dg-final { check-function-bodies "**" "" "" } } */
 
 #include <stdarg.h>

--- a/gcc/testsuite/g++.target/aarch64/pr109661-4.C
+++ b/gcc/testsuite/g++.target/aarch64/pr109661-4.C
@@ -1,4 +1,5 @@
 /* { dg-options "-O2 -Wpsabi" } */
+/* { dg-skip-if "Darwin ABI is different, test separately" { *-*-darwin* } } */
 /* { dg-final { check-function-bodies "**" "" "" } } */
 
 #include <stdarg.h>

--- a/gcc/testsuite/gcc.target/aarch64/pr109661-1.c
+++ b/gcc/testsuite/gcc.target/aarch64/pr109661-1.c
@@ -1,4 +1,5 @@
 /* { dg-options "-O2 -Wpsabi" } */
+/* { dg-skip-if "Darwin ABI is different, test separately" { *-*-darwin* } } */
 /* { dg-final { check-function-bodies "**" "" "" } } */
 
 enum __attribute__((aligned(16))) e { E };


### PR DESCRIPTION
Newly added tests, that aren't suitable for Darwin