### PR TITLE
aarch64: handle _Float128 and __float128 for C++

### DIFF
--- a/gcc/config/aarch64/aarch64-builtins.cc
+++ b/gcc/config/aarch64/aarch64-builtins.cc
@@ -1732,20 +1732,23 @@ aarch64_init_float128_types (void)
 {
   tree ftype, fndecl;
 
-  /* Populate the float128 node if it is not already done so that the FEs
-     know it is available.  */
-  if (float128_type_node == NULL_TREE)
+  /* The __float128 type.  The node has already been created as
+     _Float128, so for C we only need to register the __float128 name for
+     it.  For C++, we create a distinct type which will mangle differently
+     (g) vs. _Float128 (DF128_) and behave backwards compatibly.  */
+  if (float128t_type_node == NULL_TREE)
     {
-      float128_type_node = make_node (REAL_TYPE);
-      TYPE_PRECISION (float128_type_node) = 128;
-      SET_TYPE_MODE (float128_type_node, TFmode);
-      layout_type (float128_type_node);
+      float128t_type_node = make_node (REAL_TYPE);
+      TYPE_PRECISION (float128t_type_node)
+	= TYPE_PRECISION (float128_type_node);
+      SET_TYPE_MODE (float128t_type_node, TYPE_MODE (float128_type_node));
+      layout_type (float128t_type_node);
     }
+  lang_hooks.types.register_builtin_type (float128t_type_node, "__float128");
 
-  lang_hooks.types.register_builtin_type (float128_type_node, "__float128");
-  aarch64_float128_ptr_type_node = build_pointer_type (float128_type_node);
+  aarch64_float128_ptr_type_node = build_pointer_type (float128t_type_node);
 
-  ftype = build_function_type_list (float128_type_node, NULL_TREE);
+  ftype = build_function_type_list (float128t_type_node, NULL_TREE);
 
   fndecl = aarch64_general_add_builtin ("__builtin_huge_valq", ftype,
 					AARCH64_BUILTIN_HUGE_VALQ);

--- a/gcc/config/aarch64/aarch64.cc
+++ b/gcc/config/aarch64/aarch64.cc
@@ -21651,8 +21651,10 @@ aarch64_mangle_type (const_tree type)
 	return "Dh";
     }
 
-  /* __float128 */
-  if (TYPE_MODE (type) == TFmode)
+  /* __float128 is mangled as "g" on darwin.  _Float128 is not mangled here,
+     but handled in common code (as "DF128_").  */
+  if (TARGET_MACHO && TYPE_MODE (type) == TFmode
+      && TYPE_MAIN_VARIANT (type) == float128t_type_node)
     return "g";
 
   /* Mangle AArch64-specific internal types.  TYPE_NAME is non-NULL_TREE for

--- a/gcc/testsuite/g++.target/aarch64/float128-darwin-1.C
+++ b/gcc/testsuite/g++.target/aarch64/float128-darwin-1.C
@@ -1,0 +1,41 @@
+/* { dg-do run { target { aarch64*-*-darwin* } } } */
+/* { dg-options "-std=c++11 -std=gnu++98" } */
+
+#include <limits>
+#include <string>
+#include <typeinfo>
+
+void foo ()
+{
+  float x1 = 1.0q;
+  double x2 = 1.0q;
+  long double x3 = 1.0q;
+  
+  _Float128 w1 = 0;
+  __float128 w2 = 0;
+
+  float y1 = w1; // { dg-warning "with greater conversion rank" }
+  double y2 = w1; // { dg-warning "with greater conversion rank" }
+  long double y3 = w1; // { dg-warning "with greater conversion rank" }
+
+  float z1 = w2;
+  double z2 = w2;
+  long double z3 = w2;
+}
+
+int main ()
+{
+  // Check the correct mangling of floating-point types
+  if (typeid(float).name() != std::string("f"))
+    __builtin_abort();
+  if (typeid(double).name() != std::string("d"))
+    __builtin_abort();
+  if (typeid(long double).name() != std::string("e"))
+    __builtin_abort();
+  if (typeid(__float128).name() != std::string("g"))
+    __builtin_abort();
+  if (typeid(_Float128).name() != std::string("DF128_"))
+    __builtin_abort();
+  if (typeid(1.0q).name() != std::string("g"))
+    __builtin_abort();
+}

--- a/gcc/testsuite/gcc.target/aarch64/darwin/float128-01.c
+++ b/gcc/testsuite/gcc.target/aarch64/darwin/float128-01.c
@@ -1,0 +1,48 @@
+/* { dg-do run } */
+/* we need this for _Float128.  */
+/* { dg-options "-std=gnu99 " } */
+/* { dg-additional-options "-Wfloat-conversion" } */
+
+float f1 (__float128 z1, _Float128 z2)
+{
+  float x, y;
+  x = z1; /* { dg-warning "conversion from '_Float128' to 'float'" } */
+  y = z2; /* { dg-warning "conversion from '_Float128' to 'float'" } */
+  return x + y;
+}
+
+__float128 f2 () {
+  float f = 0.q;
+  return f;
+}
+
+_Float128 f3 () {
+  float f = 0.q;
+  return f;
+}
+
+int main ()
+{
+  __float128 x1 = __builtin_huge_valq ();
+  __float128 x2 = __builtin_infq ();
+
+  _Float128 y1 = __builtin_huge_valq ();
+  _Float128 y2 = __builtin_infq ();
+
+  if (!__builtin_isinf (x1))
+    __builtin_abort();
+  if (!__builtin_isinf (x2))
+    __builtin_abort();
+
+  if (!__builtin_isinf (y1))
+    __builtin_abort();
+  if (!__builtin_isinf (y2))
+    __builtin_abort();
+
+  if (x1 != x2)
+    __builtin_abort();
+  if (y1 != y2)
+    __builtin_abort();
+
+  return 0;
+}


### PR DESCRIPTION
~**Please don't merge yet, I will add some tests soon.**~

This change follows the discussion at https://gcc.gnu.org/pipermail/gcc/2023-August/242301.html and fixes the following test failures:

```
FAIL: g++.dg/cpp0x/gnu_fext-numeric-literals.C  -std=gnu++11  (test for errors, line 96)
FAIL: g++.dg/cpp0x/gnu_fext-numeric-literals.C  -std=gnu++11  (test for errors, line 97)
FAIL: g++.dg/cpp0x/gnu_fext-numeric-literals.C  -std=gnu++14  (test for errors, line 96)
FAIL: g++.dg/cpp0x/gnu_fext-numeric-literals.C  -std=gnu++14  (test for errors, line 97)
FAIL: g++.dg/cpp0x/gnu_fext-numeric-literals.C  -std=gnu++20  (test for errors, line 96)
FAIL: g++.dg/cpp0x/gnu_fext-numeric-literals.C  -std=gnu++20  (test for errors, line 97)
FAIL: g++.dg/cpp0x/pr77948-1.C    (test for errors, line 8)
FAIL: g++.dg/cpp0x/pr77948-1.C    (test for errors, line 9)
FAIL: g++.dg/cpp0x/pr77948-3.C    (test for errors, line 8)
FAIL: g++.dg/cpp0x/pr77948-3.C    (test for errors, line 9)
FAIL: g++.dg/cpp0x/pr77948-3.C   (test for excess errors)
FAIL: g++.dg/cpp0x/pr77948-4.C    (test for errors, line 8)
FAIL: g++.dg/cpp0x/pr77948-4.C    (test for errors, line 9)
FAIL: g++.dg/cpp0x/pr77948-4.C   (test for excess errors)
FAIL: g++.dg/cpp0x/std_fext-numeric-literals.C  -std=gnu++11  (test for errors, line 96)
FAIL: g++.dg/cpp0x/std_fext-numeric-literals.C  -std=gnu++11  (test for errors, line 97)
FAIL: g++.dg/cpp0x/std_fext-numeric-literals.C  -std=gnu++14  (test for errors, line 96)
FAIL: g++.dg/cpp0x/std_fext-numeric-literals.C  -std=gnu++14  (test for errors, line 97)
FAIL: g++.dg/cpp0x/std_fext-numeric-literals.C  -std=gnu++20  (test for errors, line 96)
FAIL: g++.dg/cpp0x/std_fext-numeric-literals.C  -std=gnu++20  (test for errors, line 97)
FAIL: g++.dg/cpp23/ext-floating11.C  -std=gnu++23 (internal compiler error: symtab_node::verify failed)
FAIL: g++.dg/cpp23/ext-floating11.C  -std=gnu++23 (test for excess errors)
FAIL: g++.dg/cpp23/ext-floating11.C  -std=gnu++26 (internal compiler error: symtab_node::verify failed)
FAIL: g++.dg/cpp23/ext-floating11.C  -std=gnu++26 (test for excess errors)
```