### PR TITLE
Implement more TFmode builtins

### DIFF
--- a/gcc/config/aarch64/aarch64-builtins.cc
+++ b/gcc/config/aarch64/aarch64-builtins.cc
@@ -2927,7 +2927,6 @@ aarch64_general_expand_builtin (unsigned int fcode, tree exp, rtx target,
       return aarch64_expand_rng_builtin (exp, target, fcode, ignore);
 
     case AARCH64_BUILTIN_COPYSIGNQ:
-    case AARCH64_BUILTIN_FABSQ:
       return expand_call (exp, target, ignore);
     }
 
@@ -3053,6 +3052,9 @@ aarch64_general_fold_builtin (unsigned int fcode, tree type,
 	    return build_real (type, nan);
 	  return NULL_TREE;
 	}
+      case AARCH64_BUILTIN_FABSQ:
+	gcc_assert (n_args == 1);
+	return fold_build1 (ABS_EXPR, type, args[0]);
       default:
 	break;
     }


### PR DESCRIPTION
Not ready for merging at this stage, first rough implementation. Will need tests.

```
In addition to
   AARCH64_BUILTIN_HUGE_VALQ
   AARCH64_BUILTIN_INFQ
we add
   AARCH64_BUILTIN_COPYSIGNQ
   AARCH64_BUILTIN_FABSQ
   AARCH64_BUILTIN_NANQ
   AARCH64_BUILTIN_NANSQ
```

- __builtin_nanq() and __builtin_nansq() are constant and always folded, like __builtin_infq() and __builtin_huge_valq() already were. I need to check that the generated NaNs have the correct payload.
- __builtin_fabsq() and __builtin_copysignq() generate library calls. The next step should be to avoid the library calls, and use the `abstf2` and `copysigntf3` patterns. I'm not sure how to do that, I think it needs `emit_insn()` but I'm not entirely sure how to use that.