### PR TITLE
Handle quad names of TFmode builtins in preprocessor

### DIFF
--- a/gcc/config/aarch64/aarch64-builtins.cc
+++ b/gcc/config/aarch64/aarch64-builtins.cc
@@ -810,8 +810,6 @@ enum aarch64_builtins
   AARCH64_RBITLL,
   /* OS-specific */
   AARCH64_BUILTIN_CFSTRING,
-  AARCH64_BUILTIN_HUGE_VALQ,
-  AARCH64_BUILTIN_INFQ,
   AARCH64_BUILTIN_MAX
 };
 
@@ -1730,8 +1728,6 @@ aarch64_init_bf16_types (void)
 static void
 aarch64_init_float128_types (void)
 {
-  tree ftype, fndecl;
-
   /* The __float128 type.  The node has already been created as
      _Float128, so for C we only need to register the __float128 name for
      it.  For C++, we create a distinct type which will mangle differently
@@ -1747,18 +1743,6 @@ aarch64_init_float128_types (void)
   lang_hooks.types.register_builtin_type (float128t_type_node, "__float128");
 
   aarch64_float128_ptr_type_node = build_pointer_type (float128t_type_node);
-
-  ftype = build_function_type_list (float128t_type_node, NULL_TREE);
-
-  fndecl = aarch64_general_add_builtin ("__builtin_huge_valq", ftype,
-					AARCH64_BUILTIN_HUGE_VALQ);
-  TREE_READONLY (fndecl) = 1;
-  aarch64_builtin_decls[AARCH64_BUILTIN_HUGE_VALQ] = fndecl;
-
-  fndecl = aarch64_general_add_builtin ("__builtin_infq", ftype,
-					AARCH64_BUILTIN_INFQ);
-  TREE_READONLY (fndecl) = 1;
-  aarch64_builtin_decls[AARCH64_BUILTIN_INFQ] = fndecl;
 }
 
 
@@ -2987,15 +2971,6 @@ aarch64_general_fold_builtin (unsigned int fcode, tree type,
 	gcc_assert (n_args == 3);
 	if (aarch64_fold_builtin_lane_check (args[0], args[1], args[2]))
 	  return void_node;
-	break;
-      case AARCH64_BUILTIN_HUGE_VALQ:
-      case AARCH64_BUILTIN_INFQ:
-	{
-	  gcc_assert (n_args == 0);
-	  REAL_VALUE_TYPE inf;
-	  real_inf (&inf);
-	  return build_real (type, inf);
-	}
 	break;
       default:
 	break;

--- a/gcc/config/aarch64/aarch64-c.cc
+++ b/gcc/config/aarch64/aarch64-c.cc
@@ -225,6 +225,16 @@ aarch64_cpu_cpp_builtins (cpp_reader *pfile)
 {
   aarch64_define_unconditional_macros (pfile);
   aarch64_update_cpp_builtins (pfile);
+
+  if (TARGET_MACHO)
+    {
+      builtin_define ("__builtin_copysignq=__builtin_copysignf128");
+      builtin_define ("__builtin_fabsq=__builtin_fabsf128");
+      builtin_define ("__builtin_huge_valq=__builtin_huge_valf128");
+      builtin_define ("__builtin_infq=__builtin_inff128");
+      builtin_define ("__builtin_nanq=__builtin_nanf128");
+      builtin_define ("__builtin_nansq=__builtin_nansf128");
+    }
 }
 
 /* Hook to validate the current #pragma GCC target and set the state, and

--- a/gcc/testsuite/gcc.target/aarch64/darwin/float128-02.c
+++ b/gcc/testsuite/gcc.target/aarch64/darwin/float128-02.c
@@ -1,0 +1,101 @@
+/* { dg-do run } */
+/* we need this for _Float128.  */
+/* { dg-options "-std=gnu99 " } */
+
+void test (__float128 z1, __float128 z2, __float128 z3, __float128 z4)
+{
+  __float128 w;
+
+  if (!__builtin_isinf (z1))
+    __builtin_abort();
+  if (__builtin_isnan (z1))
+    __builtin_abort();
+  if (__builtin_isfinite (z1))
+    __builtin_abort();
+  if (__builtin_isnormal (z1))
+    __builtin_abort();
+  if (__builtin_signbit (z1))
+    __builtin_abort();
+
+  if (__builtin_isinf (z2))
+    __builtin_abort();
+  if (!__builtin_isnan (z2))
+    __builtin_abort();
+  if (__builtin_isfinite (z2))
+    __builtin_abort();
+  if (__builtin_isnormal (z2))
+    __builtin_abort();
+  if (__builtin_signbit (z2))
+    __builtin_abort();
+
+  if (__builtin_isinf (z3))
+    __builtin_abort();
+  if (!__builtin_isnan (z3))
+    __builtin_abort();
+  if (__builtin_isfinite (z3))
+    __builtin_abort();
+  if (__builtin_isnormal (z3))
+    __builtin_abort();
+  if (__builtin_signbit (z3))
+    __builtin_abort();
+
+  if (__builtin_isinf (z4))
+    __builtin_abort();
+  if (__builtin_isnan (z4))
+    __builtin_abort();
+  if (!__builtin_isfinite (z4))
+    __builtin_abort();
+  if (!__builtin_isnormal (z4))
+    __builtin_abort();
+  if (__builtin_signbit (z4))
+    __builtin_abort();
+
+  w = __builtin_copysignq (z1, -z4);
+  if (!__builtin_signbit (w))
+    __builtin_abort();
+
+  w = __builtin_copysignq (z2, -z4);
+  if (!__builtin_signbit (w))
+    __builtin_abort();
+
+  w = __builtin_copysignq (z3, -z4);
+  if (!__builtin_signbit (w))
+    __builtin_abort();
+
+  w = __builtin_copysignq (z4, -z4);
+  if (!__builtin_signbit (w))
+    __builtin_abort();
+
+  w = __builtin_copysignq (z1, -z4);
+  w = __builtin_fabsq (w);
+  if (__builtin_signbit (w))
+    __builtin_abort();
+
+  w = __builtin_copysignq (z2, -z4);
+  w = __builtin_fabsq (w);
+  if (__builtin_signbit (w))
+    __builtin_abort();
+
+  w = __builtin_copysignq (z3, -z4);
+  w = __builtin_fabsq (w);
+  if (__builtin_signbit (w))
+    __builtin_abort();
+
+  w = __builtin_copysignq (z4, -z4);
+  w = __builtin_fabsq (w);
+  if (__builtin_signbit (w))
+    __builtin_abort();
+
+}
+
+int main ()
+{
+  __float128 x1 = __builtin_infq ();
+  __float128 x2 = __builtin_nanq ("");
+  __float128 x3 = __builtin_nansq ("");
+  __float128 x4 = 41.1094721q;
+
+  test (x1, x2, x3, x4);
+
+  return 0;
+}


### PR DESCRIPTION
Doh. Much, much easier. (The f128 builtins did not exist when I wrote the original code two or three years ago.)